### PR TITLE
fix: '/search' -> 'search'

### DIFF
--- a/components/shared/Searchbar.tsx
+++ b/components/shared/Searchbar.tsx
@@ -41,7 +41,7 @@ function Searchbar({ routeType }: Props) {
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         placeholder={`${
-          routeType !== "/search" ? "Search communities" : "Search creators"
+          routeType !== "search" ? "Search communities" : "Search creators"
         }`}
         className='no-focus searchbar_input'
       />


### PR DESCRIPTION
Fixed the placeholder display issue in the search page's search bar by modifying the conditional value in the ternary expression.