### PR TITLE
comments && communities icons fixed

### DIFF
--- a/components/cards/CommunityCard.tsx
+++ b/components/cards/CommunityCard.tsx
@@ -47,16 +47,20 @@ function CommunityCard({ id, name, username, imgUrl, bio, members }: Props) {
         {members.length > 0 && (
           <div className='flex items-center'>
             {members.map((member, index) => (
-              <Image
+              <div
                 key={index}
-                src={member.image}
-                alt={`user_${index}`}
-                width={28}
-                height={28}
-                className={`${
-                  index !== 0 && "-ml-2"
-                } rounded-full object-cover`}
-              />
+                className={`relative overflow-hidden ${index !== 0 && "-ml-2"
+                  } rounded-full`}
+                style={{ width: '24px', height: '24px' }}
+              >
+                <Image
+                  src={member.image}
+                  alt={`user_${index}`}
+                  layout='fill'
+                  objectFit='cover'
+                  className='rounded-full'
+                />
+              </div>
             ))}
             {members.length > 3 && (
               <p className='ml-1 text-subtle-medium text-gray-1'>

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -41,9 +41,8 @@ function ThreadCard({
 }: Props) {
   return (
     <article
-      className={`flex w-full flex-col rounded-xl ${
-        isComment ? "px-0 xs:px-7" : "bg-dark-2 p-7"
-      }`}
+      className={`flex w-full flex-col rounded-xl ${isComment ? "px-0 xs:px-7" : "bg-dark-2 p-7"
+        }`}
     >
       <div className='flex items-start justify-between'>
         <div className='flex w-full flex-1 flex-row gap-4'>
@@ -126,14 +125,19 @@ function ThreadCard({
       {!isComment && comments.length > 0 && (
         <div className='ml-1 mt-3 flex items-center gap-2'>
           {comments.slice(0, 2).map((comment, index) => (
-            <Image
+            <div
               key={index}
-              src={comment.author.image}
-              alt={`user_${index}`}
-              width={24}
-              height={24}
-              className={`${index !== 0 && "-ml-5"} rounded-full object-cover`}
-            />
+              className={`relative overflow-hidden rounded-full ${index !== 0 ? "-ml-5" : ""}`}
+              style={{ width: '24px', height: '24px' }}
+            >
+              <Image
+                src={comment.author.image}
+                alt={`user_${index}`}
+                layout='fill'
+                objectFit='cover'
+                className='rounded-full'
+              />
+            </div>
           ))}
 
           <Link href={`/thread/${id}`}>


### PR DESCRIPTION
Hey, JSM, there is a small issue  with icons of members of communities  in community card and commentators in the thread card. If the profile image the user has chosen is not perfectly square, his picture there appears oval instead of circle.

![image](https://github.com/adrianhajdin/threads/assets/119050285/6168a990-c56b-44cc-b21e-eb7066d3409d)
![image](https://github.com/adrianhajdin/threads/assets/119050285/5c396377-aa78-4e48-a4c0-ec96a9b17055)
![image](https://github.com/adrianhajdin/threads/assets/119050285/2b845cd7-9ddd-4ad0-94c3-72ad175b7bd9)

So I fixed this by wrapping the <Image/> into separate <div> please review this and thanks again for your contribution to web devs community! 